### PR TITLE
added support for the new schema endpoint

### DIFF
--- a/src/services/api/v4/schema.service.ts
+++ b/src/services/api/v4/schema.service.ts
@@ -1,0 +1,16 @@
+import { ICredentialType } from "@/interfaces/api/v2/credential-type.interface";
+import Http, { HttpResponse } from "@/services/http.service";
+import ApiResource from "@/services/api/resource.service";
+
+export default class SchemaType extends ApiResource {
+  baseVersion = "v4";
+  basePath = "schemas";
+
+  async getSchemaTypes(): Promise<
+    HttpResponse<Record<string, ICredentialType[]>>
+  > {
+    return await Http.get<Record<string, ICredentialType[]>>(
+      this.formatEndpointUrl("")
+    );
+  }
+}

--- a/src/store/modules/credential-type.ts
+++ b/src/store/modules/credential-type.ts
@@ -5,15 +5,19 @@ import {
   ICredentialTypeByIssuer,
 } from "@/interfaces/api/v2/credential-type.interface";
 import CredentialType from "@/services/api/v4/credential-type.service";
+import SchemaType from "@/services/api/v4/schema.service";
 
 const credentialTypeSerivice = new CredentialType();
+const schemaTypeService = new SchemaType();
 
 export interface State {
+  schemaTypes: Record<string, ICredentialType[]>;
   types: ICredentialType[];
   selected: ICredentialType | null;
 }
 
 const state: State = {
+  schemaTypes: {},
   types: [],
   selected: null,
 };
@@ -21,6 +25,8 @@ const state: State = {
 const getters = {
   credentialType: (state: State): ICredentialType | null => state.selected,
   credentialTypes: (state: State): ICredentialType[] => state.types,
+  schemaTypes: (state: State): Record<string, ICredentialType[]> =>
+    state.schemaTypes,
   credentialTypesByIssuer: (state: State): ICredentialTypeByIssuer[] =>
     Object.values(
       state.types.reduce(
@@ -56,9 +62,23 @@ const actions = {
       commit("setTypes", []);
     }
   },
+  async fetchSchemaTypes({
+    commit,
+  }: ActionContext<State, RootState>): Promise<void> {
+    try {
+      const res = await schemaTypeService.getSchemaTypes();
+      commit("setSchemaTypes", res.data);
+    } catch (e) {
+      console.error(e);
+      commit("setSchemaTypes", {});
+    }
+  },
 };
 
 const mutations = {
+  setSchemaTypes(state: State, types: Record<string, ICredentialType[]>): void {
+    state.schemaTypes = { ...types };
+  },
   setTypes(state: State, types: ICredentialType[]): void {
     state.types = [...types];
   },


### PR DESCRIPTION
allows the ability to group credential type versions by schema.
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>