### PR TITLE
fixed the "about api" links

### DIFF
--- a/src/docs/orgbook_api.md
+++ b/src/docs/orgbook_api.md
@@ -10,8 +10,8 @@ showcaseDescription: Learn about the developer tools—the “API”—for addin
 
 Anyone is able to use OrgBook BC data in their own services. Rather than needing to use the OrgBook BC website interface, the data is available directly from OrgBook BC using what developers call an API. Your developers could use this, for example, to integrate OrgBook BC data into your business processes.
 
-Developers can review the [API specification](http://orgbook.gov.bc.ca/api) and the [API documentation](). There is also an [API demo]() for developers to see it in action.
+Developers can review the [API specification](http://orgbook.gov.bc.ca/api/) and the [API documentation](https://github.com/bcgov/orgbook-api). There is also an [API demo](https://github.com/bcgov/orgbook-api/tree/main/demo) for developers to see it in action.
 
-Any use of the API is subject to the [terms of service]().
+Any use of the API is subject to the [terms of service](https://github.com/bcgov/orgbook-api/blob/main/LICENSE).
 
 If you have any questions about the API or its potential, [get in touch](/contact) with our team.


### PR DESCRIPTION
pointed the links to the correct location on `orgbook-api` page
Signed-off-by: wadeking98 <wkingnumber2@gmail.com>